### PR TITLE
Use rospack to find config script

### DIFF
--- a/segway_v3_config/env-hooks/50.segway_config.sh
+++ b/segway_v3_config/env-hooks/50.segway_config.sh
@@ -2,4 +2,4 @@
 # This is necessary to run before starting the simulation 
 #
 
-source $HOME/segway_ws/src/segway_v3/segway_v3_config/segway_config.sh
+source $(rospack find segway_v3_config)/segway_config.sh


### PR DESCRIPTION
This avoids needing to hardcode the location of the catkin workspace.