### PR TITLE
Fix order of cmake calls

### DIFF
--- a/segway_ros/CMakeLists.txt
+++ b/segway_ros/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(segway_ros)
 
+find_package(catkin REQUIRED COMPONENTS roslaunch rospy dynamic_reconfigure)
+
 ## Uncomment if the package has a setup.py
 catkin_python_setup()
-
-find_package(catkin REQUIRED COMPONENTS roslaunch rospy dynamic_reconfigure)
 
 generate_dynamic_reconfigure_options(cfg/segway.cfg)
 


### PR DESCRIPTION
`find_package(catkin ...)` needs to come before `catkin_python_setup()` because catkin's find_package macro is what defines `catkin_python_setup()`

The only reason this built before is that it was always built in cmake workspaces with other packages that happened to get built first and call `find_package(catkin ...)`. To catch this bug, I had to run `catkin_make_isolated`