### PR TITLE
Use system cmake info for Eigen when available

### DIFF
--- a/segway_navigation/segway_assisted_teleop/CMakeLists.txt
+++ b/segway_navigation/segway_assisted_teleop/CMakeLists.txt
@@ -20,20 +20,38 @@ set(THIS_PACKAGE_ROS_DEPS
 )
 
 find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS})
-find_package(Eigen REQUIRED)
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS} ${Eigen_LIBRARY_DIRS})
+# Starting in ROS Jade, using cmake_modules to find Eigen is deprecated.
+# Instead, find_package(Eigen3) is called which uses the cmake config included
+# with the system install of Eigen. For compatibility with older ROS distros,
+# we fall back to the cmake_modules version if needed.
+#
+# See http://wiki.ros.org/jade/Migration#Eigen_CMake_Module_in_cmake_modules
+#
+find_package(Eigen3)
+if(NOT EIGEN3_FOUND)
+  message(EIGEN3 not found)
+
+  # Fallback to cmake_modules
+  find_package(cmake_modules REQUIRED)
+  find_package(Eigen REQUIRED)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+else()
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
+
+include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
+link_directories(${catkin_LIBRARY_DIRS} ${EIGEN3_LIBRARY_DIRS})
 message("Assisted telop catkin_LIBRARY_DIRS: " ${catkin_LIBRARY_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS ${THIS_PACKAGE_ROS_DEPS}
-  DEPENDS Eigen
+  INCLUDE_DIRS ${EIGEN3_INCLUDE_DIRS}
 )
 
 add_executable(segway_assisted_teleop src/segway_assisted_teleop.cpp)
-target_link_libraries(segway_assisted_teleop trajectory_planner_ros ${catkin_LIBRARIES} ${Eigen_LIBRARIES})
+target_link_libraries(segway_assisted_teleop trajectory_planner_ros ${catkin_LIBRARIES})
 
 install(TARGETS segway_assisted_teleop
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/segway_navigation/segway_assisted_teleop/CMakeLists.txt
+++ b/segway_navigation/segway_assisted_teleop/CMakeLists.txt
@@ -30,8 +30,6 @@ find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS})
 #
 find_package(Eigen3)
 if(NOT EIGEN3_FOUND)
-  message(EIGEN3 not found)
-
   # Fallback to cmake_modules
   find_package(cmake_modules REQUIRED)
   find_package(Eigen REQUIRED)
@@ -42,7 +40,6 @@ endif()
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS} ${EIGEN3_LIBRARY_DIRS})
-message("Assisted telop catkin_LIBRARY_DIRS: " ${catkin_LIBRARY_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include


### PR DESCRIPTION
Starting in ROS jade, using cmake_modules to find eigen is deprecated: http://wiki.ros.org/jade/Migration#Eigen_CMake_Module_in_cmake_modules

This uses the new way of finding Eigen, which will work for jade and kinetic, and falls back to cmake_modules if needed. I've tested this on kinetic - someone should test it on indigo before merging though.